### PR TITLE
Implicitly deny privilege escalation for crd check pod in gitop chart

### DIFF
--- a/charts/gitops-operator/templates/wait-for-crd.yaml
+++ b/charts/gitops-operator/templates/wait-for-crd.yaml
@@ -16,6 +16,13 @@ spec:
     image: quay.io/openshift/origin-cli:latest
     imagePullPolicy: IfNotPresent
     command: ['sh', '-c', 'while [ true ]; do oc get crd argocds.argoproj.io applications.argoproj.io appprojects.argoproj.io; if [ $? -eq 0 ]; then break; fi ; sleep 5s; done']
+    securityContext:
+      allowPrivilegeEscalation: false
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+        - ALL
   restartPolicy: Never
   terminationGracePeriodSeconds: 0
   serviceAccount: default


### PR DESCRIPTION
Running the Gitops operator helm chart in ocp 4.15 or 4.16 causes the below error. Implicitly denying privilege escalation allows the helm chart to proceed.

```
helm.go:84: [debug] post-upgrade hooks failed: warning: Hook post-upgrade gitops-operator/templates/wait-for-crd.yaml failed: 1 error occurred:
        * pods "cluster-check" is forbidden: violates PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "crd-check" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "crd-check" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "crd-check" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "crd-check" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

Tested this on ocp 4.16 + ocp 4.15 and both install without error