### PR TITLE
FLPATH-1338 - Default to latest channel for gitops to deploy on ocp 4.16

### DIFF
--- a/charts/gitops-operator/values.yaml
+++ b/charts/gitops-operator/values.yaml
@@ -11,7 +11,7 @@ namespaces:
 
 # operator manages upgrades
 operator:
-  channel: gitops-1.10
+  channel: latest
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   sourceName: redhat-operators


### PR DESCRIPTION
Sets gitops operator to use the latest channel by default in the helm chart. 

Currently the gitops operator is pinned to channel 1.10, but this will fail on ocp 4.16. Latest has been tested and works.

